### PR TITLE
feat: 데이터베이스 설정 및 프로젝트 기본 엔티티, 컨버터 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,14 +29,14 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
+//    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'
+//    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/project/hireup/HireupApplication.java
+++ b/src/main/java/com/project/hireup/HireupApplication.java
@@ -2,12 +2,14 @@ package com.project.hireup;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class HireupApplication {
 
-    public static void main(String[] args) {
-        SpringApplication.run(HireupApplication.class, args);
-    }
+  public static void main(String[] args) {
+    SpringApplication.run(HireupApplication.class, args);
+  }
 
 }

--- a/src/main/java/com/project/hireup/converter/StringSetConverter.java
+++ b/src/main/java/com/project/hireup/converter/StringSetConverter.java
@@ -1,0 +1,34 @@
+package com.project.hireup.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.HashSet;
+import java.util.Set;
+
+@Converter
+public class StringSetConverter implements AttributeConverter<Set<String>, String> {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Override
+  public String convertToDatabaseColumn(Set<String> attribute) {
+    try {
+      return objectMapper.writeValueAsString(attribute);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Set을 JSON으로 변환하는 중 오류가 발생했습니다", e);
+    }
+  }
+
+  @Override
+  public Set<String> convertToEntityAttribute(String dbData) {
+    try {
+      return objectMapper.readValue(dbData, new TypeReference<HashSet<String>>() {
+      });
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("JSON을 Set으로 변환하는 중 오류가 발생했습니다", e);
+    }
+  }
+}

--- a/src/main/java/com/project/hireup/entity/Category.java
+++ b/src/main/java/com/project/hireup/entity/Category.java
@@ -1,0 +1,38 @@
+package com.project.hireup.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "categories")
+public class Category {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(length = 50, nullable = false)
+  private String name;
+
+  @Column(nullable = false)
+  private boolean isNotice;
+
+  @OneToMany(mappedBy = "category")
+  private List<Post> posts;
+}

--- a/src/main/java/com/project/hireup/entity/Comment.java
+++ b/src/main/java/com/project/hireup/entity/Comment.java
@@ -1,0 +1,52 @@
+package com.project.hireup.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class Comment {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(length = 500, nullable = false)
+  private String content;
+
+  @CreatedDate
+  @Column(updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  private LocalDateTime updatedAt;
+
+  // 댓글 작성자
+  @ManyToOne
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @ManyToOne
+  @JoinColumn(name = "post_id", nullable = false)
+  private Post post;
+}

--- a/src/main/java/com/project/hireup/entity/Follow.java
+++ b/src/main/java/com/project/hireup/entity/Follow.java
@@ -1,0 +1,34 @@
+package com.project.hireup.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Follow {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne
+  @JoinColumn(name = "follower_id", nullable = false)
+  private User follower;
+
+  @ManyToOne
+  @JoinColumn(name = "following_id", nullable = false)
+  private User following;
+}

--- a/src/main/java/com/project/hireup/entity/Like.java
+++ b/src/main/java/com/project/hireup/entity/Like.java
@@ -1,0 +1,38 @@
+package com.project.hireup.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "likes")
+public class Like {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  // 좋아요를 누른 사람
+  @ManyToOne
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  // 좋아요가 눌린 게시글
+  @ManyToOne
+  @JoinColumn(name = "post_id", nullable = false)
+  private Post post;
+}

--- a/src/main/java/com/project/hireup/entity/Notification.java
+++ b/src/main/java/com/project/hireup/entity/Notification.java
@@ -1,0 +1,48 @@
+package com.project.hireup.entity;
+
+import com.project.hireup.type.NotificationType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class Notification {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private NotificationType type; // 알림 유형 (댓글, 좋아요 등)
+
+  @CreatedDate
+  @Column(updatable = false)
+  private LocalDateTime createdAt;
+
+  @ManyToOne
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+}

--- a/src/main/java/com/project/hireup/entity/Post.java
+++ b/src/main/java/com/project/hireup/entity/Post.java
@@ -1,0 +1,88 @@
+package com.project.hireup.entity;
+
+import com.project.hireup.converter.StringSetConverter;
+import com.project.hireup.type.PostStatus;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class Post {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(length = 200, nullable = false)
+  private String title;
+
+  @Lob
+  @Column(columnDefinition = "TEXT", nullable = false)
+  private String content;
+
+  @Column(columnDefinition = "JSON")
+  @Convert(converter = StringSetConverter.class)
+  private Set<String> hashtags = new HashSet<>();
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private PostStatus status = PostStatus.PUBLIC;
+
+  @CreatedDate
+  @Column(updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  private LocalDateTime updatedAt;
+
+  @ManyToOne
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @ManyToOne
+  @JoinColumn(name = "category_id", nullable = false)
+  private Category category;
+
+  @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Comment> comments;
+
+  @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Like> likes;
+
+  @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Report> reports;
+
+  @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<PostImage> images = new ArrayList<>();
+
+}

--- a/src/main/java/com/project/hireup/entity/PostImage.java
+++ b/src/main/java/com/project/hireup/entity/PostImage.java
@@ -1,0 +1,34 @@
+package com.project.hireup.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostImage {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne
+  @JoinColumn(name = "post_id", nullable = false)
+  private Post post;
+
+  @Column(nullable = false)
+  private String imageUrl;
+}

--- a/src/main/java/com/project/hireup/entity/Report.java
+++ b/src/main/java/com/project/hireup/entity/Report.java
@@ -1,0 +1,47 @@
+package com.project.hireup.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class Report {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne
+  @JoinColumn(name = "user_id", nullable = false)
+  private User reporter; // 신고자
+
+  @ManyToOne
+  @JoinColumn(name = "post_id", nullable = false)
+  private Post post; // 신고된 게시글
+
+  @Column(length = 500,nullable = false)
+  private String reason; // 신고 사유
+
+  @CreatedDate
+  @Column(updatable = false)
+  private LocalDateTime reportedAt; // 신고 일시
+}

--- a/src/main/java/com/project/hireup/entity/User.java
+++ b/src/main/java/com/project/hireup/entity/User.java
@@ -1,0 +1,82 @@
+package com.project.hireup.entity;
+
+import com.project.hireup.type.UserStatus;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class User {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(length = 100, nullable = false, unique = true)
+  private String email;
+
+  @Column(length = 50, nullable = false)
+  private String name;
+
+  @Column(length = 100, nullable = false)
+  private String password;
+
+  @Column(length = 10, nullable = false)
+  private String emailVerificationCode;
+
+  @Column(nullable = false)
+  private Boolean isEmailVerified = false;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private UserStatus status = UserStatus.ACTIVE;
+
+  @Column(nullable = false)
+  private Boolean isAdmin = false;
+
+  @CreatedDate
+  @Column(updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  private LocalDateTime updatedAt;
+
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Post> posts;
+
+  @OneToMany(mappedBy = "reporter", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Report> reports;
+
+  @OneToMany(mappedBy = "follower", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Follow> followers;
+
+  @OneToMany(mappedBy = "following", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Follow> followings;
+
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Notification> notifications;
+
+}

--- a/src/main/java/com/project/hireup/entity/User.java
+++ b/src/main/java/com/project/hireup/entity/User.java
@@ -67,9 +67,6 @@ public class User {
   @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Post> posts;
 
-  @OneToMany(mappedBy = "reporter", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<Report> reports;
-
   @OneToMany(mappedBy = "follower", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Follow> followers;
 

--- a/src/main/java/com/project/hireup/entity/Weather.java
+++ b/src/main/java/com/project/hireup/entity/Weather.java
@@ -1,0 +1,27 @@
+package com.project.hireup.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class Weather {
+
+  @Id
+  private LocalDateTime date;
+  private String weather;
+  private String icon;
+  private double temperature;
+  private String description;
+
+}

--- a/src/main/java/com/project/hireup/type/NotificationType.java
+++ b/src/main/java/com/project/hireup/type/NotificationType.java
@@ -1,0 +1,7 @@
+package com.project.hireup.type;
+
+public enum NotificationType {
+  COMMENT,   // 댓글 알림
+  LIKE,      // 좋아요 알림
+  FOLLOW,    // 팔로우 알림
+}

--- a/src/main/java/com/project/hireup/type/PostStatus.java
+++ b/src/main/java/com/project/hireup/type/PostStatus.java
@@ -1,0 +1,5 @@
+package com.project.hireup.type;
+
+public enum PostStatus {
+  PUBLIC, PRIVATE, FOLLOWER
+}

--- a/src/main/java/com/project/hireup/type/UserStatus.java
+++ b/src/main/java/com/project/hireup/type/UserStatus.java
@@ -1,0 +1,5 @@
+package com.project.hireup.type;
+
+public enum UserStatus {
+  ACTIVE, SUSPENDED
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,16 @@
 spring:
   application:
     name: hireup
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?serverTimezone=UTC&characterEncoding=UTF-8
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+
+  jpa:
+    show-sql: true
+    database: mysql
+    hibernate:
+      ddl-auto: update
+    generate-ddl: true


### PR DESCRIPTION
### 변경사항

**AS-IS**
- 데이터베이스 미설정
- 프로젝트 초기 상태로 엔티티와 데이터 모델이 정의되지 않음.
- 해시태그 JSON 저장 로직 미구현.

**TO-BE**
- 데이터베이스 설정
- User, Post, Comment, Category 등 주요 엔티티 정의.
- 해시태그를 JSON 형태로 저장하기 위한 `StringSetConverter` 구현.