### PR TITLE
feat: 사용자 정보 조회, 프로필 조회, 비밀번호 변경, 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/project/hireup/config/SecurityConfig.java
+++ b/src/main/java/com/project/hireup/config/SecurityConfig.java
@@ -31,7 +31,8 @@ public class SecurityConfig {
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(auth -> auth
             .requestMatchers("/api/auth/**").permitAll() // 인증 없이 접근 가능한 경로(모든 사용자 접근 허용)
-            .requestMatchers("/swagger-ui/**","/swagger-ui.html", "/v3/api-docs/**").permitAll() // Swagger 관련 경로 허용
+            .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**")
+            .permitAll() // Swagger 관련 경로 허용
             .requestMatchers("/api/admin/**").hasAuthority("ROLE_ADMIN") // Admin만 접근 가능
             .anyRequest().authenticated() // 그 외 모든 요청은 인증 필요
         )

--- a/src/main/java/com/project/hireup/config/SecurityConfig.java
+++ b/src/main/java/com/project/hireup/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
         .sessionManagement(
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(auth -> auth
-            .requestMatchers("/api/user/**").permitAll() // 인증 없이 접근 가능한 경로(모든 사용자 접근 허용)
+            .requestMatchers("/api/auth/**").permitAll() // 인증 없이 접근 가능한 경로(모든 사용자 접근 허용)
             .requestMatchers("/swagger-ui/**","/swagger-ui.html", "/v3/api-docs/**").permitAll() // Swagger 관련 경로 허용
             .requestMatchers("/api/admin/**").hasAuthority("ROLE_ADMIN") // Admin만 접근 가능
             .anyRequest().authenticated() // 그 외 모든 요청은 인증 필요

--- a/src/main/java/com/project/hireup/controller/AuthController.java
+++ b/src/main/java/com/project/hireup/controller/AuthController.java
@@ -1,0 +1,48 @@
+package com.project.hireup.controller;
+
+import com.project.hireup.dto.SignInRequestDto;
+import com.project.hireup.dto.SignUpRequestDto;
+import com.project.hireup.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+  private final AuthService userService;
+
+  @Operation(summary = "회원가입", description = "사용자의 이메일, 비밀번호 등을 입력받아 회원가입을 처리합니다.")
+  @PostMapping("/sign-up")
+  public ResponseEntity<String> signUp(@Valid @RequestBody SignUpRequestDto requestDto) {
+
+    userService.signUp(requestDto);
+
+    return ResponseEntity.ok("회원가입이 성공적으로 완료되었습니다.");
+  }
+
+  @Operation(summary = "로그인", description = "이메일과 비밀번호를 입력받아 JWT 토큰을 반환합니다.")
+  @PostMapping("/sign-in")
+  public ResponseEntity<String> signIn(@Valid @RequestBody SignInRequestDto requestDto) {
+    String token = userService.signIn(requestDto.getEmail(), requestDto.getPassword());
+    return ResponseEntity.ok(token);
+  }
+
+  @Operation(summary = "이메일 인증", description = "이메일 인증 링크를 통해 계정 활성화 상태를 변경합니다.")
+  @GetMapping("/email-auth")
+  public ResponseEntity<String> emailAuth(@RequestParam String uuid) {
+
+    userService.emailAuth(uuid);
+
+    return ResponseEntity.ok("이메일 인증이 성공적으로 완료되었습니다.");
+  }
+}

--- a/src/main/java/com/project/hireup/controller/UserController.java
+++ b/src/main/java/com/project/hireup/controller/UserController.java
@@ -1,48 +1,33 @@
 package com.project.hireup.controller;
 
-import com.project.hireup.dto.SignInRequestDto;
-import com.project.hireup.dto.SignUpRequestDto;
+import com.project.hireup.dto.UserResponseDto;
 import com.project.hireup.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
-import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@Validated // 유효성 검사 활성화
 @RequestMapping("/api/user")
 public class UserController {
 
   private final UserService userService;
 
-  @Operation(summary = "회원가입", description = "사용자의 이메일, 비밀번호 등을 입력받아 회원가입을 처리합니다.")
-  @PostMapping("/sign-up")
-  public ResponseEntity<String> signUp(@Valid @RequestBody SignUpRequestDto requestDto) {
+  // 이름으로 정보 조회
+  @Operation(summary = "이름으로 사용자 조회", description = "사용자 이름을 통해 여러 사용자를 조회합니다.")
+  @GetMapping("/search/name")
+  public ResponseEntity<List<UserResponseDto>> searchByName(
+      @RequestParam @NotBlank(message = "이름은 필수 입력 항목입니다.") String name) {
 
-    userService.signUp(requestDto);
-
-    return ResponseEntity.ok("회원가입이 성공적으로 완료되었습니다.");
-  }
-
-  @Operation(summary = "로그인", description = "이메일과 비밀번호를 입력받아 JWT 토큰을 반환합니다.")
-  @PostMapping("/sign-in")
-  public ResponseEntity<String> signIn(@Valid @RequestBody SignInRequestDto requestDto) {
-    String token = userService.signIn(requestDto.getEmail(), requestDto.getPassword());
-    return ResponseEntity.ok(token);
-  }
-
-  @Operation(summary = "이메일 인증", description = "이메일 인증 링크를 통해 계정 활성화 상태를 변경합니다.")
-  @GetMapping("/email-auth")
-  public ResponseEntity<String> emailAuth(@RequestParam String uuid) {
-
-    userService.emailAuth(uuid);
-
-    return ResponseEntity.ok("이메일 인증이 성공적으로 완료되었습니다.");
+    List<UserResponseDto> users = userService.searchByName(name);
+    return ResponseEntity.ok(users);
   }
 }

--- a/src/main/java/com/project/hireup/controller/UserController.java
+++ b/src/main/java/com/project/hireup/controller/UserController.java
@@ -2,6 +2,7 @@ package com.project.hireup.controller;
 
 import com.project.hireup.dto.MyProfileResponseDto;
 import com.project.hireup.dto.PasswordChangeRequestDto;
+import com.project.hireup.dto.PasswordRequestDto;
 import com.project.hireup.dto.UserResponseDto;
 import com.project.hireup.exception.HireUpException;
 import com.project.hireup.security.UserDetailsImpl;
@@ -69,9 +70,10 @@ public class UserController {
   @Operation(summary = "회원 탈퇴", description = "회원 탈퇴 기능으로 회원 목록에서 삭제합니다.")
   @DeleteMapping("/delete-account")
   public ResponseEntity<String> deleteAccount(
+      @RequestBody @Valid PasswordRequestDto requestDto,
       @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
-    userService.deleteAccount(userDetails.getEmail());
+    userService.deleteAccount(userDetails.getEmail(), requestDto.getPassword());
     return ResponseEntity.ok("회원 탈퇴가 성공적으로 완료되었습니다.");
   }
 }

--- a/src/main/java/com/project/hireup/controller/UserController.java
+++ b/src/main/java/com/project/hireup/controller/UserController.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -62,5 +63,15 @@ public class UserController {
 
     userService.changePassword(requestDto, userDetails.getEmail());
     return ResponseEntity.ok("비밀번호가 성공적으로 변경되었습니다.");
+  }
+
+  // 회원 탈퇴
+  @Operation(summary = "회원 탈퇴", description = "회원 탈퇴 기능으로 회원 목록에서 삭제합니다.")
+  @DeleteMapping("/delete-account")
+  public ResponseEntity<String> deleteAccount(
+      @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+    userService.deleteAccount(userDetails.getEmail());
+    return ResponseEntity.ok("회원 탈퇴가 성공적으로 완료되었습니다.");
   }
 }

--- a/src/main/java/com/project/hireup/controller/UserController.java
+++ b/src/main/java/com/project/hireup/controller/UserController.java
@@ -1,7 +1,9 @@
 package com.project.hireup.controller;
 
 import com.project.hireup.dto.UserResponseDto;
+import com.project.hireup.exception.HireUpException;
 import com.project.hireup.service.UserService;
+import com.project.hireup.type.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.constraints.NotBlank;
 import java.util.List;
@@ -28,6 +30,9 @@ public class UserController {
       @RequestParam @NotBlank(message = "이름은 필수 입력 항목입니다.") String name) {
 
     List<UserResponseDto> users = userService.searchByName(name);
+    if (users.isEmpty()) {
+      throw new HireUpException(ErrorCode.NOT_EXIST_NAME);
+    }
     return ResponseEntity.ok(users);
   }
 }

--- a/src/main/java/com/project/hireup/controller/UserController.java
+++ b/src/main/java/com/project/hireup/controller/UserController.java
@@ -51,7 +51,7 @@ public class UserController {
   public ResponseEntity<MyProfileResponseDto> getMyProfile(
       @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
-    MyProfileResponseDto myProfile = userService.getMyProfile(userDetails.getEmail());
+    MyProfileResponseDto myProfile = userService.getMyProfile(userDetails.getId());
     return ResponseEntity.ok(myProfile);
   }
 
@@ -62,7 +62,7 @@ public class UserController {
       @RequestBody @Valid PasswordChangeRequestDto requestDto,
       @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
-    userService.changePassword(requestDto, userDetails.getEmail());
+    userService.changePassword(requestDto, userDetails.getId());
     return ResponseEntity.ok("비밀번호가 성공적으로 변경되었습니다.");
   }
 
@@ -73,7 +73,7 @@ public class UserController {
       @RequestBody @Valid PasswordRequestDto requestDto,
       @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
-    userService.deleteAccount(userDetails.getEmail(), requestDto.getPassword());
+    userService.deleteAccount(userDetails.getId(), requestDto.getPassword());
     return ResponseEntity.ok("회원 탈퇴가 성공적으로 완료되었습니다.");
   }
 }

--- a/src/main/java/com/project/hireup/controller/UserController.java
+++ b/src/main/java/com/project/hireup/controller/UserController.java
@@ -1,7 +1,9 @@
 package com.project.hireup.controller;
 
+import com.project.hireup.dto.MyProfileResponseDto;
 import com.project.hireup.dto.UserResponseDto;
 import com.project.hireup.exception.HireUpException;
+import com.project.hireup.security.UserDetailsImpl;
 import com.project.hireup.service.UserService;
 import com.project.hireup.type.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,6 +11,7 @@ import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,4 +38,13 @@ public class UserController {
     }
     return ResponseEntity.ok(users);
   }
+
+  // 나의 프로필 조회
+  @Operation(summary = "나의 프로필 조회", description = "현재 로그인된 사용자의 프로필 정보를 조회합니다.")
+  @GetMapping("/my-profile")
+  public ResponseEntity<MyProfileResponseDto> getMyProfile(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    MyProfileResponseDto myProfile = userService.getMyProfile(userDetails.getEmail());
+    return ResponseEntity.ok(myProfile);
+  }
+
 }

--- a/src/main/java/com/project/hireup/controller/UserController.java
+++ b/src/main/java/com/project/hireup/controller/UserController.java
@@ -1,12 +1,14 @@
 package com.project.hireup.controller;
 
 import com.project.hireup.dto.MyProfileResponseDto;
+import com.project.hireup.dto.PasswordChangeRequestDto;
 import com.project.hireup.dto.UserResponseDto;
 import com.project.hireup.exception.HireUpException;
 import com.project.hireup.security.UserDetailsImpl;
 import com.project.hireup.service.UserService;
 import com.project.hireup.type.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +16,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -42,9 +46,21 @@ public class UserController {
   // 나의 프로필 조회
   @Operation(summary = "나의 프로필 조회", description = "현재 로그인된 사용자의 프로필 정보를 조회합니다.")
   @GetMapping("/my-profile")
-  public ResponseEntity<MyProfileResponseDto> getMyProfile(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+  public ResponseEntity<MyProfileResponseDto> getMyProfile(
+      @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
     MyProfileResponseDto myProfile = userService.getMyProfile(userDetails.getEmail());
     return ResponseEntity.ok(myProfile);
   }
 
+  // 비밀번호 변경
+  @Operation(summary = "비밀번호 변경", description = "새로운 비밀번호를 받아 비밀번호를 변경합니다.")
+  @PutMapping("/change-password")
+  public ResponseEntity<String> changePassword(
+      @RequestBody @Valid PasswordChangeRequestDto requestDto,
+      @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+    userService.changePassword(requestDto, userDetails.getEmail());
+    return ResponseEntity.ok("비밀번호가 성공적으로 변경되었습니다.");
+  }
 }

--- a/src/main/java/com/project/hireup/dto/MyProfileResponseDto.java
+++ b/src/main/java/com/project/hireup/dto/MyProfileResponseDto.java
@@ -1,0 +1,42 @@
+package com.project.hireup.dto;
+
+import com.project.hireup.entity.User;
+import com.project.hireup.type.UserRole;
+import com.project.hireup.type.UserStatus;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MyProfileResponseDto {
+
+  private Long id;
+  private String email;
+  private String name;
+  private boolean emailAuthYn;
+  private UserStatus status;
+  private UserRole userRole;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+
+  public static MyProfileResponseDto fromEntity(User user) {
+    return MyProfileResponseDto.builder()
+        .id(user.getId())
+        .email(user.getEmail())
+        .name(user.getName())
+        .emailAuthYn(user.isEmailAuthYn())
+        .status(user.getStatus())
+        .userRole(user.getUserRole())
+        .createdAt(user.getCreatedAt())
+        .updatedAt(user.getUpdatedAt())
+        .build();
+  }
+
+}

--- a/src/main/java/com/project/hireup/dto/PasswordChangeRequestDto.java
+++ b/src/main/java/com/project/hireup/dto/PasswordChangeRequestDto.java
@@ -1,0 +1,28 @@
+package com.project.hireup.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PasswordChangeRequestDto {
+
+  @NotBlank(message = "기존 비밀번호는 필수 입력 항목입니다.")
+  private String currentPassword;
+
+  @NotBlank(message = "새로운 비밀번호는 필수 입력 항목입니다.")
+  @Size(min = 8, max = 20, message = "비밀번호는 최소 8자 이상, 최대 20자 이하여야 합니다.")
+  private String newPassword;
+
+  @NotBlank(message = "비밀번호 확인은 필수 입력 항목입니다.")
+  private String confirmPassword;
+
+}

--- a/src/main/java/com/project/hireup/dto/PasswordRequestDto.java
+++ b/src/main/java/com/project/hireup/dto/PasswordRequestDto.java
@@ -1,0 +1,17 @@
+package com.project.hireup.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordRequestDto {
+
+  @NotBlank(message = "비밀번호는 필수 입력 사항입니다.")
+  private String password;
+}

--- a/src/main/java/com/project/hireup/dto/UserResponseDto.java
+++ b/src/main/java/com/project/hireup/dto/UserResponseDto.java
@@ -18,14 +18,12 @@ public class UserResponseDto {
   private Long id; // 사용자 ID
   private String email; // 사용자 이메일
   private String name; // 사용자 이름
-  private UserStatus status; // 사용자 계정 상태
 
   public static UserResponseDto fromEntity(User user) {
     return UserResponseDto.builder()
         .id(user.getId())
         .email(user.getEmail())
         .name(user.getName())
-        .status(user.getStatus())
         .build();
   }
 

--- a/src/main/java/com/project/hireup/dto/UserResponseDto.java
+++ b/src/main/java/com/project/hireup/dto/UserResponseDto.java
@@ -1,7 +1,6 @@
 package com.project.hireup.dto;
 
 import com.project.hireup.entity.User;
-import com.project.hireup.type.UserStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/project/hireup/dto/UserResponseDto.java
+++ b/src/main/java/com/project/hireup/dto/UserResponseDto.java
@@ -1,0 +1,32 @@
+package com.project.hireup.dto;
+
+import com.project.hireup.entity.User;
+import com.project.hireup.type.UserStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserResponseDto {
+
+  private Long id; // 사용자 ID
+  private String email; // 사용자 이메일
+  private String name; // 사용자 이름
+  private UserStatus status; // 사용자 계정 상태
+
+  public static UserResponseDto fromEntity(User user) {
+    return UserResponseDto.builder()
+        .id(user.getId())
+        .email(user.getEmail())
+        .name(user.getName())
+        .status(user.getStatus())
+        .build();
+  }
+
+}

--- a/src/main/java/com/project/hireup/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/project/hireup/jwt/JwtTokenProvider.java
@@ -45,12 +45,13 @@ public class JwtTokenProvider {
   }
 
   // 토큰 생성
-  public String createToken(String email, String role, String userStatus) {
+  public String createToken(Long id, String email, String role, String userStatus) {
     Date now = new Date();
     Date expiryDate = new Date(now.getTime() + tokenTime);
 
     return Jwts.builder()
         .setSubject(email) // JWT payload의 subject(email)
+        .claim("id", id) // 사용자 ID 추가
         .claim("role", role) // 권한 정보
         .claim("status", userStatus) // UserStatus 추가
         .setIssuedAt(now) // 발급 시간
@@ -89,6 +90,7 @@ public class JwtTokenProvider {
         .parseClaimsJws(token)
         .getBody();
 
+    Long id = claims.get("id", Long.class); // JWT에서 ID 추출
     String email = claims.getSubject(); // JWT에서 email 추출
     String roleString = claims.get("role", String.class); // JWT에서 role을 String으로 가져옴
     String statusString = claims.get("status", String.class); // JWT에서 userStatus 가져오기
@@ -98,7 +100,7 @@ public class JwtTokenProvider {
     UserStatus status = UserStatus.valueOf(statusString); // String -> Enum 변환
 
     // UserDetailsImpl에 JWT 정보만 전달
-    UserDetails userDetails = new UserDetailsImpl(email, "", role, status);
+    UserDetails userDetails = new UserDetailsImpl(id, email, "", role, status);
 
     return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
   }

--- a/src/main/java/com/project/hireup/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/project/hireup/jwt/JwtTokenProvider.java
@@ -36,7 +36,7 @@ public class JwtTokenProvider {
   // 암호화 알고리즘
   private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
 
-  private final long tokenTime = 1000L * 60 * 60; // 1시간
+  private final long tokenTime = 1000L * 60 * 60 * 24; // 1시간
 
   // Bean 생성 후 자동 실행 (secretKey를 Key 객체로 변환하여 저장)
   @PostConstruct

--- a/src/main/java/com/project/hireup/repository/UserRepository.java
+++ b/src/main/java/com/project/hireup/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.project.hireup.repository;
 
 import com.project.hireup.entity.User;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -13,4 +14,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByEmailAuthKey(String emailAuthKey);
 
   Optional<User> findByEmail(String email);
+
+  List<User> findAllByName(String name);
 }

--- a/src/main/java/com/project/hireup/security/UserDetailsImpl.java
+++ b/src/main/java/com/project/hireup/security/UserDetailsImpl.java
@@ -12,13 +12,16 @@ import org.springframework.security.core.userdetails.UserDetails;
 @Getter
 public class UserDetailsImpl implements UserDetails {
 
+  private final Long id; // 사용자 ID 추가
   private final String email;
   private final String password;
   private final UserRole userRole;
   private final UserStatus userStatus;
   private final Collection<? extends GrantedAuthority> authorities;
 
-  public UserDetailsImpl(String email, String password, UserRole userRole, UserStatus userStatus) {
+  public UserDetailsImpl(Long id, String email, String password, UserRole userRole,
+      UserStatus userStatus) {
+    this.id = id;
     this.email = email;
     this.password = password;
     this.userRole = userRole;

--- a/src/main/java/com/project/hireup/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/project/hireup/security/UserDetailsServiceImpl.java
@@ -19,6 +19,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     User user = userRepository.findByEmail(email)
         .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
 
-    return new UserDetailsImpl(user.getEmail(), user.getPassword(), user.getUserRole(), user.getStatus());
+    return new UserDetailsImpl(user.getId(), user.getEmail(), user.getPassword(),
+        user.getUserRole(), user.getStatus());
   }
 }

--- a/src/main/java/com/project/hireup/service/AuthService.java
+++ b/src/main/java/com/project/hireup/service/AuthService.java
@@ -5,7 +5,7 @@ import static com.project.hireup.type.ErrorCode.EMAIL_UNVERIFIED;
 import static com.project.hireup.type.ErrorCode.INVALID_PASSWORD;
 import static com.project.hireup.type.ErrorCode.NOT_EQUAL_CONFIRM_PASSWORD;
 import static com.project.hireup.type.ErrorCode.NOT_EQUAL_TOKEN;
-import static com.project.hireup.type.ErrorCode.NOT_EXIST_EMAIL;
+import static com.project.hireup.type.ErrorCode.NOT_EXIST_ACCOUNT;
 import static com.project.hireup.type.ErrorCode.NOT_EXIST_EMAIL_AUTH_KEY;
 import static com.project.hireup.type.ErrorCode.SUSPENDED_USER;
 import static com.project.hireup.type.ErrorCode.USER_ALREADY_EXISTS;
@@ -87,7 +87,7 @@ public class AuthService {
   public String signIn(String email, String password) {
     // 이메일로 사용자 조회
     User user = userRepository.findByEmail(email)
-        .orElseThrow(() -> new HireUpException(NOT_EXIST_EMAIL));
+        .orElseThrow(() -> new HireUpException(NOT_EXIST_ACCOUNT));
 
     // 비밀번호 검증
     if (!passwordEncoder.matches(password, user.getPassword())) {
@@ -103,7 +103,7 @@ public class AuthService {
     }
 
     // JWT 토큰 생성
-    return jwtTokenProvider.createToken(user.getEmail(), user.getUserRole().name(),
+    return jwtTokenProvider.createToken(user.getId(), user.getEmail(), user.getUserRole().name(),
         user.getStatus().name());
   }
 

--- a/src/main/java/com/project/hireup/service/AuthService.java
+++ b/src/main/java/com/project/hireup/service/AuthService.java
@@ -23,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -40,6 +41,7 @@ public class AuthService {
   private String baseUrl;
 
   // 회원가입
+  @Transactional
   public void signUp(SignUpRequestDto requestDto) {
 
     // 회원가입 진행 -> 이미 등록된 email이 있다면 예외 처리
@@ -106,6 +108,7 @@ public class AuthService {
   }
 
   // 이메일 인증
+  @Transactional
   public void emailAuth(String uuid) {
 
     User user = userRepository.findByEmailAuthKey(uuid)

--- a/src/main/java/com/project/hireup/service/AuthService.java
+++ b/src/main/java/com/project/hireup/service/AuthService.java
@@ -1,0 +1,137 @@
+package com.project.hireup.service;
+
+import static com.project.hireup.type.ErrorCode.ALREADY_AUTH;
+import static com.project.hireup.type.ErrorCode.EMAIL_UNVERIFIED;
+import static com.project.hireup.type.ErrorCode.INVALID_PASSWORD;
+import static com.project.hireup.type.ErrorCode.NOT_EQUAL_CONFIRM_PASSWORD;
+import static com.project.hireup.type.ErrorCode.NOT_EQUAL_TOKEN;
+import static com.project.hireup.type.ErrorCode.NOT_EXIST_EMAIL;
+import static com.project.hireup.type.ErrorCode.NOT_EXIST_EMAIL_AUTH_KEY;
+import static com.project.hireup.type.ErrorCode.SUSPENDED_USER;
+import static com.project.hireup.type.ErrorCode.USER_ALREADY_EXISTS;
+
+import com.project.hireup.component.MailComponent;
+import com.project.hireup.dto.SignUpRequestDto;
+import com.project.hireup.entity.User;
+import com.project.hireup.exception.HireUpException;
+import com.project.hireup.jwt.JwtTokenProvider;
+import com.project.hireup.repository.UserRepository;
+import com.project.hireup.type.UserRole;
+import com.project.hireup.type.UserStatus;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+  private final UserRepository userRepository;
+  private final MailComponent mailComponent;
+  private final PasswordEncoder passwordEncoder;
+  private final JwtTokenProvider jwtTokenProvider;
+
+  @Value("${admin.token}")
+  private String adminToken;
+
+  @Value("${base.url}")
+  private String baseUrl;
+
+  // 회원가입
+  public void signUp(SignUpRequestDto requestDto) {
+
+    // 회원가입 진행 -> 이미 등록된 email이 있다면 예외 처리
+    if (userRepository.existsByEmail(requestDto.getEmail())) {
+      throw new HireUpException(USER_ALREADY_EXISTS);
+    }
+
+    // 비밀번호와 비밀번호 확인 입력이 다를시 예외 처리
+    if (!requestDto.getPassword().equals(requestDto.getConfirmPassword())) {
+      throw new HireUpException(NOT_EQUAL_CONFIRM_PASSWORD);
+    }
+
+    // isAdmin 값이 true 이고 함께 넣어준 토큰 값이 일치한다면 Partner role 부여
+    UserRole role = determineUserRole(requestDto);
+
+    // email 인증 키를 UUID를 사용하여 랜덤 값으로 생성
+    String uuid = UUID.randomUUID().toString();
+
+    User user = User.builder()
+        .email(requestDto.getEmail())
+        .name(requestDto.getName())
+        .password(passwordEncoder.encode(requestDto.getPassword())) // 비밀번호 암호화 적용
+        .emailAuthKey(uuid)
+        .userRole(role)
+        .emailAuthYn(false)
+        .status(UserStatus.UNVERIFIED)
+        .build();
+    userRepository.save(user);
+
+    String email = requestDto.getEmail();
+    String subject = "HireUp 사이트 가입을 환영합니다!";
+    String text = "<p>" + requestDto.getName() + "님, HireUp 사이트 가입을 환영합니다!</p>"
+        + "<p>아래 링크를 클릭하셔서 가입을 완료하세요.</p>"
+        + "<div><a target='_blank' href='" + baseUrl + "/api/auth/email-auth?uuid=" + uuid
+        + "'>가입 완료</a></div>"
+        + "<p>가입을 완료하시면 HireUp의 다양한 서비스를 이용하실 수 있습니다.</p>"
+        + "<p>감사합니다.</p>";
+
+    mailComponent.sendMail(email, subject, text);
+  }
+
+  // 로그인
+  public String signIn(String email, String password) {
+    // 이메일로 사용자 조회
+    User user = userRepository.findByEmail(email)
+        .orElseThrow(() -> new HireUpException(NOT_EXIST_EMAIL));
+
+    // 비밀번호 검증
+    if (!passwordEncoder.matches(password, user.getPassword())) {
+      throw new HireUpException(INVALID_PASSWORD);
+    }
+
+    // 계정 상태 확인
+    if (user.getStatus() == UserStatus.UNVERIFIED) { // 이메일 인증이 되지 않은 유저 로그인 방지
+      throw new HireUpException(EMAIL_UNVERIFIED);
+    }
+    if (user.getStatus() == UserStatus.SUSPENDED) { // 정지된 유저 로그인 방지
+      throw new HireUpException(SUSPENDED_USER);
+    }
+
+    // JWT 토큰 생성
+    return jwtTokenProvider.createToken(user.getEmail(), user.getUserRole().name(),
+        user.getStatus().name());
+  }
+
+  // 이메일 인증
+  public void emailAuth(String uuid) {
+
+    User user = userRepository.findByEmailAuthKey(uuid)
+        .orElseThrow(() -> new HireUpException(NOT_EXIST_EMAIL_AUTH_KEY));
+
+    if (user.isEmailAuthYn()) {
+      throw new HireUpException(ALREADY_AUTH);
+    }
+
+    user.setEmailAuthYn(true);
+    user.setStatus(UserStatus.ACTIVE);
+    userRepository.save(user);
+  }
+
+  // 유저에게 권한 부여하는 메서드 생성
+  private UserRole determineUserRole(SignUpRequestDto requestDto) {
+    if (requestDto.isAdmin()) {
+      validateAdminToken(requestDto.getAdminToken());
+      return UserRole.ROLE_ADMIN;
+    }
+    return UserRole.ROLE_USER;
+  }
+
+  private void validateAdminToken(String adminToken) {
+    if (!this.adminToken.equals(adminToken)) {
+      throw new HireUpException(NOT_EQUAL_TOKEN);
+    }
+  }
+}

--- a/src/main/java/com/project/hireup/service/UserService.java
+++ b/src/main/java/com/project/hireup/service/UserService.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -54,6 +55,7 @@ public class UserService {
   }
 
   // 비밀번호 변경
+  @Transactional
   public void changePassword(@Valid PasswordChangeRequestDto requestDto, String email) {
 
     User user = userRepository.findByEmail(email)
@@ -80,6 +82,7 @@ public class UserService {
   }
 
   // 회원 탈퇴
+  @Transactional
   public void deleteAccount(String email) {
 
     User user = userRepository.findByEmail(email)

--- a/src/main/java/com/project/hireup/service/UserService.java
+++ b/src/main/java/com/project/hireup/service/UserService.java
@@ -1,5 +1,6 @@
 package com.project.hireup.service;
 
+import static com.project.hireup.type.ErrorCode.*;
 import static com.project.hireup.type.ErrorCode.DO_NOT_EQUAL_CURRENT_PASSWORD;
 import static com.project.hireup.type.ErrorCode.NOT_EQUAL_CONFIRM_PASSWORD;
 import static com.project.hireup.type.ErrorCode.NOT_EQUAL_CURRENT_PASSWORD;
@@ -49,7 +50,7 @@ public class UserService {
   public MyProfileResponseDto getMyProfile(Long id) {
 
     User user = userRepository.findById(id)
-        .orElseThrow(() -> new HireUpException(ErrorCode.NOT_EXIST_ACCOUNT));
+        .orElseThrow(() -> new HireUpException(NOT_EXIST_ACCOUNT));
 
     return MyProfileResponseDto.fromEntity(user);
   }
@@ -59,7 +60,7 @@ public class UserService {
   public void changePassword(@Valid PasswordChangeRequestDto requestDto, Long id) {
 
     User user = userRepository.findById(id)
-        .orElseThrow(() -> new HireUpException(ErrorCode.NOT_EXIST_ACCOUNT));
+        .orElseThrow(() -> new HireUpException(NOT_EXIST_ACCOUNT));
 
     // 기존 비밀번호 검증
     if (!passwordEncoder.matches(requestDto.getCurrentPassword(), user.getPassword())) {
@@ -86,7 +87,7 @@ public class UserService {
   public void deleteAccount(Long id, String password) {
 
     User user = userRepository.findById(id)
-        .orElseThrow(() -> new HireUpException(ErrorCode.NOT_EXIST_ACCOUNT));
+        .orElseThrow(() -> new HireUpException(NOT_EXIST_ACCOUNT));
 
     if (!passwordEncoder.matches(password, user.getPassword())) {
       throw new HireUpException(NOT_EQUAL_CURRENT_PASSWORD);

--- a/src/main/java/com/project/hireup/service/UserService.java
+++ b/src/main/java/com/project/hireup/service/UserService.java
@@ -77,4 +77,14 @@ public class UserService {
     user.setPassword(passwordEncoder.encode(requestDto.getNewPassword()));
     userRepository.save(user);
   }
+
+  // 회원 탈퇴
+  public void deleteAccount(String email) {
+
+    // 이미 로그인을 성공하고 조회하는 것이기 때문에 바로 get 으로 user 객체 가져오기
+    User user = userRepository.findByEmail(email).get();
+
+    // 사용자 삭제
+    userRepository.delete(user);
+  }
 }

--- a/src/main/java/com/project/hireup/service/UserService.java
+++ b/src/main/java/com/project/hireup/service/UserService.java
@@ -1,27 +1,15 @@
 package com.project.hireup.service;
 
-import static com.project.hireup.type.ErrorCode.ALREADY_AUTH;
-import static com.project.hireup.type.ErrorCode.EMAIL_UNVERIFIED;
-import static com.project.hireup.type.ErrorCode.INVALID_PASSWORD;
-import static com.project.hireup.type.ErrorCode.NOT_EQUAL_CONFIRM_PASSWORD;
-import static com.project.hireup.type.ErrorCode.NOT_EQUAL_TOKEN;
-import static com.project.hireup.type.ErrorCode.NOT_EXIST_EMAIL;
-import static com.project.hireup.type.ErrorCode.NOT_EXIST_EMAIL_AUTH_KEY;
-import static com.project.hireup.type.ErrorCode.SUSPENDED_USER;
-import static com.project.hireup.type.ErrorCode.USER_ALREADY_EXISTS;
-
-import com.project.hireup.component.MailComponent;
-import com.project.hireup.dto.SignUpRequestDto;
+import com.project.hireup.dto.UserResponseDto;
 import com.project.hireup.entity.User;
 import com.project.hireup.exception.HireUpException;
-import com.project.hireup.jwt.JwtTokenProvider;
 import com.project.hireup.repository.UserRepository;
+import com.project.hireup.type.ErrorCode;
 import com.project.hireup.type.UserRole;
-import com.project.hireup.type.UserStatus;
-import java.util.UUID;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -29,109 +17,20 @@ import org.springframework.stereotype.Service;
 public class UserService {
 
   private final UserRepository userRepository;
-  private final MailComponent mailComponent;
-  private final PasswordEncoder passwordEncoder;
-  private final JwtTokenProvider jwtTokenProvider;
 
-  @Value("${admin.token}")
-  private String adminToken;
+  public List<UserResponseDto> searchByName(String name) {
+    List<User> users = userRepository.findAllByName(name);
 
-  @Value("${base.url}")
-  private String baseUrl;
-
-  // 회원가입
-  public void signUp(SignUpRequestDto requestDto) {
-
-    // 회원가입 진행 -> 이미 등록된 email이 있다면 예외 처리
-    if (userRepository.existsByEmail(requestDto.getEmail())) {
-      throw new HireUpException(USER_ALREADY_EXISTS);
+    // 해당 이름으로 생성된 계정이 없을시 예외
+    if (users.isEmpty()) {
+      throw new HireUpException(ErrorCode.NOT_EXIST_NAME);
     }
 
-    // 비밀번호와 비밀번호 확인 입력이 다를시 예외 처리
-    if (!requestDto.getPassword().equals(requestDto.getConfirmPassword())) {
-      throw new HireUpException(NOT_EQUAL_CONFIRM_PASSWORD);
-    }
-
-    // isAdmin 값이 true 이고 함께 넣어준 토큰 값이 일치한다면 Partner role 부여
-    UserRole role = determineUserRole(requestDto);
-
-    // email 인증 키를 UUID를 사용하여 랜덤 값으로 생성
-    String uuid = UUID.randomUUID().toString();
-
-    User user = User.builder()
-        .email(requestDto.getEmail())
-        .name(requestDto.getName())
-        .password(passwordEncoder.encode(requestDto.getPassword())) // 비밀번호 암호화 적용
-        .emailAuthKey(uuid)
-        .userRole(role)
-        .emailAuthYn(false)
-        .status(UserStatus.UNVERIFIED)
-        .build();
-    userRepository.save(user);
-
-    String email = requestDto.getEmail();
-    String subject = "HireUp 사이트 가입을 환영합니다!";
-    String text = "<p>" + requestDto.getName() + "님, HireUp 사이트 가입을 환영합니다!</p>"
-        + "<p>아래 링크를 클릭하셔서 가입을 완료하세요.</p>"
-        + "<div><a target='_blank' href='" + baseUrl + "/api/user/email-auth?uuid=" + uuid
-        + "'>가입 완료</a></div>"
-        + "<p>가입을 완료하시면 HireUp의 다양한 서비스를 이용하실 수 있습니다.</p>"
-        + "<p>감사합니다.</p>";
-
-    mailComponent.sendMail(email, subject, text);
+    return users.stream()
+        // ROLE_USER 만 조회 가능
+        .filter(user -> user.getUserRole() == UserRole.ROLE_USER)
+        .map(UserResponseDto::fromEntity)
+        .collect(Collectors.toList());
   }
 
-  // 로그인
-  public String signIn(String email, String password) {
-    // 이메일로 사용자 조회
-    User user = userRepository.findByEmail(email)
-        .orElseThrow(() -> new HireUpException(NOT_EXIST_EMAIL));
-
-    // 비밀번호 검증
-    if (!passwordEncoder.matches(password, user.getPassword())) {
-      throw new HireUpException(INVALID_PASSWORD);
-    }
-
-    // 계정 상태 확인
-    if (user.getStatus() == UserStatus.UNVERIFIED) { // 이메일 인증이 되지 않은 유저 로그인 방지
-      throw new HireUpException(EMAIL_UNVERIFIED);
-    }
-    if (user.getStatus() == UserStatus.SUSPENDED) { // 정지된 유저 로그인 방지
-      throw new HireUpException(SUSPENDED_USER);
-    }
-
-    // JWT 토큰 생성
-    return jwtTokenProvider.createToken(user.getEmail(), user.getUserRole().name(),
-        user.getStatus().name());
-  }
-
-  // 이메일 인증
-  public void emailAuth(String uuid) {
-
-    User user = userRepository.findByEmailAuthKey(uuid)
-        .orElseThrow(() -> new HireUpException(NOT_EXIST_EMAIL_AUTH_KEY));
-
-    if (user.isEmailAuthYn()) {
-      throw new HireUpException(ALREADY_AUTH);
-    }
-
-    user.setEmailAuthYn(true);
-    user.setStatus(UserStatus.ACTIVE);
-    userRepository.save(user);
-  }
-
-  // 유저에게 권한 부여하는 메서드 생성
-  private UserRole determineUserRole(SignUpRequestDto requestDto) {
-    if (requestDto.isAdmin()) {
-      validateAdminToken(requestDto.getAdminToken());
-      return UserRole.ROLE_ADMIN;
-    }
-    return UserRole.ROLE_USER;
-  }
-
-  private void validateAdminToken(String adminToken) {
-    if (!this.adminToken.equals(adminToken)) {
-      throw new HireUpException(NOT_EQUAL_TOKEN);
-    }
-  }
 }

--- a/src/main/java/com/project/hireup/service/UserService.java
+++ b/src/main/java/com/project/hireup/service/UserService.java
@@ -83,10 +83,14 @@ public class UserService {
 
   // 회원 탈퇴
   @Transactional
-  public void deleteAccount(String email) {
+  public void deleteAccount(String email, String password) {
 
     User user = userRepository.findByEmail(email)
         .orElseThrow(() -> new HireUpException(ErrorCode.NOT_EXIST_EMAIL));
+
+    if (!passwordEncoder.matches(password, user.getPassword())) {
+      throw new HireUpException(NOT_EQUAL_CURRENT_PASSWORD);
+    }
 
     // 사용자 삭제
     userRepository.delete(user);

--- a/src/main/java/com/project/hireup/service/UserService.java
+++ b/src/main/java/com/project/hireup/service/UserService.java
@@ -46,20 +46,20 @@ public class UserService {
   }
 
   // 나의 프로필 조회
-  public MyProfileResponseDto getMyProfile(String email) {
+  public MyProfileResponseDto getMyProfile(Long id) {
 
-    User user = userRepository.findByEmail(email)
-        .orElseThrow(() -> new HireUpException(ErrorCode.NOT_EXIST_EMAIL));
+    User user = userRepository.findById(id)
+        .orElseThrow(() -> new HireUpException(ErrorCode.NOT_EXIST_ACCOUNT));
 
     return MyProfileResponseDto.fromEntity(user);
   }
 
   // 비밀번호 변경
   @Transactional
-  public void changePassword(@Valid PasswordChangeRequestDto requestDto, String email) {
+  public void changePassword(@Valid PasswordChangeRequestDto requestDto, Long id) {
 
-    User user = userRepository.findByEmail(email)
-        .orElseThrow(() -> new HireUpException(ErrorCode.NOT_EXIST_EMAIL));
+    User user = userRepository.findById(id)
+        .orElseThrow(() -> new HireUpException(ErrorCode.NOT_EXIST_ACCOUNT));
 
     // 기존 비밀번호 검증
     if (!passwordEncoder.matches(requestDto.getCurrentPassword(), user.getPassword())) {
@@ -83,10 +83,10 @@ public class UserService {
 
   // 회원 탈퇴
   @Transactional
-  public void deleteAccount(String email, String password) {
+  public void deleteAccount(Long id, String password) {
 
-    User user = userRepository.findByEmail(email)
-        .orElseThrow(() -> new HireUpException(ErrorCode.NOT_EXIST_EMAIL));
+    User user = userRepository.findById(id)
+        .orElseThrow(() -> new HireUpException(ErrorCode.NOT_EXIST_ACCOUNT));
 
     if (!passwordEncoder.matches(password, user.getPassword())) {
       throw new HireUpException(NOT_EQUAL_CURRENT_PASSWORD);

--- a/src/main/java/com/project/hireup/service/UserService.java
+++ b/src/main/java/com/project/hireup/service/UserService.java
@@ -1,17 +1,23 @@
 package com.project.hireup.service;
 
+import static com.project.hireup.type.ErrorCode.DO_NOT_EQUAL_CURRENT_PASSWORD;
+import static com.project.hireup.type.ErrorCode.NOT_EQUAL_CONFIRM_PASSWORD;
+import static com.project.hireup.type.ErrorCode.NOT_EQUAL_CURRENT_PASSWORD;
+import static com.project.hireup.type.ErrorCode.NOT_EXIST_NAME;
+import static com.project.hireup.type.UserRole.ROLE_USER;
+import static com.project.hireup.type.UserStatus.ACTIVE;
+
 import com.project.hireup.dto.MyProfileResponseDto;
+import com.project.hireup.dto.PasswordChangeRequestDto;
 import com.project.hireup.dto.UserResponseDto;
 import com.project.hireup.entity.User;
 import com.project.hireup.exception.HireUpException;
 import com.project.hireup.repository.UserRepository;
-import com.project.hireup.type.ErrorCode;
-import com.project.hireup.type.UserRole;
-import com.project.hireup.type.UserStatus;
-import java.util.ArrayList;
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -19,30 +25,56 @@ import org.springframework.stereotype.Service;
 public class UserService {
 
   private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
 
+  // 이름으로 정보 조회
   public List<UserResponseDto> searchByName(String name) {
     List<User> users = userRepository.findAllByName(name);
 
     // 해당 이름으로 생성된 계정이 없을시 예외
     if (users.isEmpty()) {
-      throw new HireUpException(ErrorCode.NOT_EXIST_NAME);
+      throw new HireUpException(NOT_EXIST_NAME);
     }
 
     return users.stream()
-        // ROLE_USER 만 조회 가능
-        .filter(user -> user.getUserRole() == UserRole.ROLE_USER) // ROLE_USER만 필터링
-        .filter(user -> user.getStatus() == UserStatus.ACTIVE) // ACTIVE 상태만 필터링
+        .filter(user -> user.getUserRole() == ROLE_USER) // ROLE_USER만 필터링
+        .filter(user -> user.getStatus() == ACTIVE) // ACTIVE 상태만 필터링
         .map(UserResponseDto::fromEntity)
         .collect(Collectors.toList());
   }
 
+  // 나의 프로필 조회
   public MyProfileResponseDto getMyProfile(String email) {
 
-    // 이미 로그인을 성공하고 조회하는 것이기 때문에 바로 get으로 user 객체 가져오기
+    // 이미 로그인을 성공하고 조회하는 것이기 때문에 바로 get 으로 user 객체 가져오기
     User user = userRepository.findByEmail(email).get();
 
     return MyProfileResponseDto.fromEntity(user);
-
   }
 
+  // 비밀번호 변경
+  public void changePassword(@Valid PasswordChangeRequestDto requestDto, String email) {
+
+    // 이미 로그인을 성공하고 조회하는 것이기 때문에 바로 get 으로 user 객체 가져오기
+    User user = userRepository.findByEmail(email).get();
+
+    // 기존 비밀번호 검증
+    if (!passwordEncoder.matches(requestDto.getCurrentPassword(), user.getPassword())) {
+      throw new HireUpException(NOT_EQUAL_CURRENT_PASSWORD);
+    }
+
+    // 기존 비밀번호와 새로운 비밀번호가 같은지 검증
+    if (requestDto.getCurrentPassword().equals(requestDto.getNewPassword())) {
+      throw new HireUpException(DO_NOT_EQUAL_CURRENT_PASSWORD);
+    }
+
+    // 새로운 비밀번호와 비밀번호 확인 검증
+    if (!requestDto.getNewPassword().equals(requestDto.getConfirmPassword())) {
+      throw new HireUpException(NOT_EQUAL_CONFIRM_PASSWORD);
+    }
+
+    // 새로운 비밀번호로 업데이트
+    user.setPassword(passwordEncoder.encode(requestDto.getNewPassword()));
+    userRepository.save(user);
+  }
 }

--- a/src/main/java/com/project/hireup/service/UserService.java
+++ b/src/main/java/com/project/hireup/service/UserService.java
@@ -6,6 +6,7 @@ import com.project.hireup.exception.HireUpException;
 import com.project.hireup.repository.UserRepository;
 import com.project.hireup.type.ErrorCode;
 import com.project.hireup.type.UserRole;
+import com.project.hireup.type.UserStatus;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -28,7 +29,8 @@ public class UserService {
 
     return users.stream()
         // ROLE_USER 만 조회 가능
-        .filter(user -> user.getUserRole() == UserRole.ROLE_USER)
+        .filter(user -> user.getUserRole() == UserRole.ROLE_USER) // ROLE_USER만 필터링
+        .filter(user -> user.getStatus() == UserStatus.ACTIVE) // ACTIVE 상태만 필터링
         .map(UserResponseDto::fromEntity)
         .collect(Collectors.toList());
   }

--- a/src/main/java/com/project/hireup/service/UserService.java
+++ b/src/main/java/com/project/hireup/service/UserService.java
@@ -13,6 +13,7 @@ import com.project.hireup.dto.UserResponseDto;
 import com.project.hireup.entity.User;
 import com.project.hireup.exception.HireUpException;
 import com.project.hireup.repository.UserRepository;
+import com.project.hireup.type.ErrorCode;
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -46,8 +47,8 @@ public class UserService {
   // 나의 프로필 조회
   public MyProfileResponseDto getMyProfile(String email) {
 
-    // 이미 로그인을 성공하고 조회하는 것이기 때문에 바로 get 으로 user 객체 가져오기
-    User user = userRepository.findByEmail(email).get();
+    User user = userRepository.findByEmail(email)
+        .orElseThrow(() -> new HireUpException(ErrorCode.NOT_EXIST_EMAIL));
 
     return MyProfileResponseDto.fromEntity(user);
   }
@@ -55,15 +56,15 @@ public class UserService {
   // 비밀번호 변경
   public void changePassword(@Valid PasswordChangeRequestDto requestDto, String email) {
 
-    // 이미 로그인을 성공하고 조회하는 것이기 때문에 바로 get 으로 user 객체 가져오기
-    User user = userRepository.findByEmail(email).get();
+    User user = userRepository.findByEmail(email)
+        .orElseThrow(() -> new HireUpException(ErrorCode.NOT_EXIST_EMAIL));
 
     // 기존 비밀번호 검증
     if (!passwordEncoder.matches(requestDto.getCurrentPassword(), user.getPassword())) {
       throw new HireUpException(NOT_EQUAL_CURRENT_PASSWORD);
     }
 
-    // 기존 비밀번호와 새로운 비밀번호가 같은지 검증
+    // 입력한 기존 비밀번호와 새로운 비밀번호가 같은지 검증
     if (requestDto.getCurrentPassword().equals(requestDto.getNewPassword())) {
       throw new HireUpException(DO_NOT_EQUAL_CURRENT_PASSWORD);
     }
@@ -81,8 +82,8 @@ public class UserService {
   // 회원 탈퇴
   public void deleteAccount(String email) {
 
-    // 이미 로그인을 성공하고 조회하는 것이기 때문에 바로 get 으로 user 객체 가져오기
-    User user = userRepository.findByEmail(email).get();
+    User user = userRepository.findByEmail(email)
+        .orElseThrow(() -> new HireUpException(ErrorCode.NOT_EXIST_EMAIL));
 
     // 사용자 삭제
     userRepository.delete(user);

--- a/src/main/java/com/project/hireup/service/UserService.java
+++ b/src/main/java/com/project/hireup/service/UserService.java
@@ -1,5 +1,6 @@
 package com.project.hireup.service;
 
+import com.project.hireup.dto.MyProfileResponseDto;
 import com.project.hireup.dto.UserResponseDto;
 import com.project.hireup.entity.User;
 import com.project.hireup.exception.HireUpException;
@@ -33,6 +34,15 @@ public class UserService {
         .filter(user -> user.getStatus() == UserStatus.ACTIVE) // ACTIVE 상태만 필터링
         .map(UserResponseDto::fromEntity)
         .collect(Collectors.toList());
+  }
+
+  public MyProfileResponseDto getMyProfile(String email) {
+
+    // 이미 로그인을 성공하고 조회하는 것이기 때문에 바로 get으로 user 객체 가져오기
+    User user = userRepository.findByEmail(email).get();
+
+    return MyProfileResponseDto.fromEntity(user);
+
   }
 
 }

--- a/src/main/java/com/project/hireup/type/ErrorCode.java
+++ b/src/main/java/com/project/hireup/type/ErrorCode.java
@@ -16,6 +16,8 @@ public enum ErrorCode {
   INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
   USER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 등록된 회원입니다."),
   NOT_EQUAL_CONFIRM_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+  NOT_EQUAL_CURRENT_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호가 일치하지 않습니다."),
+  DO_NOT_EQUAL_CURRENT_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호로는 변경할 수 없습니다."),
   INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 올바르지 않습니다."),
   NOT_EQUAL_TOKEN(HttpStatus.BAD_REQUEST, "토큰 값이 일치하지 않습니다."),
   NOT_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "해당 계정은 존재하지 않습니다."),

--- a/src/main/java/com/project/hireup/type/ErrorCode.java
+++ b/src/main/java/com/project/hireup/type/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
   NOT_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "해당 계정은 존재하지 않습니다."),
   NOT_EXIST_EMAIL_AUTH_KEY(HttpStatus.BAD_REQUEST, "해당 이메일 인증 키는 존재하지 않습니다."),
   ALREADY_AUTH(HttpStatus.BAD_REQUEST, "이미 이메일 인증을 완료했습니다."),
+  NOT_EXIST_NAME(HttpStatus.BAD_REQUEST, "해당 이름을 가진 계정은 없습니다."),
 
   // 403 FORBIDDEN (접근 금지)
   EMAIL_UNVERIFIED(HttpStatus.FORBIDDEN, "이메일 인증이 완료되지 않은 계정입니다."),

--- a/src/main/java/com/project/hireup/type/ErrorCode.java
+++ b/src/main/java/com/project/hireup/type/ErrorCode.java
@@ -20,7 +20,7 @@ public enum ErrorCode {
   DO_NOT_EQUAL_CURRENT_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호로는 변경할 수 없습니다."),
   INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 올바르지 않습니다."),
   NOT_EQUAL_TOKEN(HttpStatus.BAD_REQUEST, "토큰 값이 일치하지 않습니다."),
-  NOT_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "해당 계정은 존재하지 않습니다."),
+  NOT_EXIST_ACCOUNT(HttpStatus.BAD_REQUEST, "해당 계정은 존재하지 않습니다."),
   NOT_EXIST_EMAIL_AUTH_KEY(HttpStatus.BAD_REQUEST, "해당 이메일 인증 키는 존재하지 않습니다."),
   ALREADY_AUTH(HttpStatus.BAD_REQUEST, "이미 이메일 인증을 완료했습니다."),
   NOT_EXIST_NAME(HttpStatus.BAD_REQUEST, "해당 이름을 가진 계정이 없습니다."),

--- a/src/main/java/com/project/hireup/type/ErrorCode.java
+++ b/src/main/java/com/project/hireup/type/ErrorCode.java
@@ -21,7 +21,7 @@ public enum ErrorCode {
   NOT_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "해당 계정은 존재하지 않습니다."),
   NOT_EXIST_EMAIL_AUTH_KEY(HttpStatus.BAD_REQUEST, "해당 이메일 인증 키는 존재하지 않습니다."),
   ALREADY_AUTH(HttpStatus.BAD_REQUEST, "이미 이메일 인증을 완료했습니다."),
-  NOT_EXIST_NAME(HttpStatus.BAD_REQUEST, "해당 이름을 가진 계정은 없습니다."),
+  NOT_EXIST_NAME(HttpStatus.BAD_REQUEST, "해당 이름을 가진 계정이 없습니다."),
 
   // 403 FORBIDDEN (접근 금지)
   EMAIL_UNVERIFIED(HttpStatus.FORBIDDEN, "이메일 인증이 완료되지 않은 계정입니다."),


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 회원가입, 로그인을 UserController에서 관리
- 사용자 정보 조회, 프로필 조회, 비밀번호 변경, 회원 탈퇴와 관련된 기능이 미구현 상태.

**TO-BE**
- 회원가입, 로그인을 AuthController에서 관리
  - 조회, 변경, 탈퇴 기능을 UserController에서 관리

- 사용자 정보 조회:
  - 이름으로 사용자 정보를 검색하는 API 추가 (`GET /api/user/search/name`).
  - `UserResponseDto`를 통해 최소한의 사용자 정보 반환.

- 나의 프로필 조회:
  - 현재 로그인된 사용자의 프로필 정보를 조회하는 API 추가 (`GET /api/user/my-profile`).
  - `MyProfileResponseDto`를 통해 상세 사용자 정보 반환 (이메일 인증 여부, 역할, 상태 등 포함).

- 비밀번호 변경:
  - 기존 비밀번호와 새로운 비밀번호를 받아 비밀번호를 변경하는 API 추가 (`PUT /api/user/change-password`).
  - `PasswordChangeRequestDto`를 통해 기존 비밀번호, 새로운 비밀번호, 비밀번호 확인 필드 포함.
  - 비밀번호 검증 로직 추가:
    - 기존 비밀번호가 일치하지 않을 경우 예외 발생.
    - 새로운 비밀번호와 기존 비밀번호가 같을 경우 예외 발생.
    - 새로운 비밀번호와 확인 비밀번호가 일치하지 않을 경우 예외 발생.

- 회원 탈퇴:
  - 현재 로그인된 사용자를 삭제하는 API 추가 (`DELETE /api/user/delete-account`).
  - 이메일을 기반으로 사용자 삭제.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 (Postman)