### PR TITLE
feat: ElasticSearch 도입, ElasticSearch를 활용한 게시글 검색 기능 구현 및 PostService 연동

### DIFF
--- a/src/main/java/com/project/hireup/controller/PostSearchController.java
+++ b/src/main/java/com/project/hireup/controller/PostSearchController.java
@@ -3,8 +3,11 @@ package com.project.hireup.controller;
 import com.project.hireup.entity.PostDocument;
 import com.project.hireup.service.PostSearchService;
 import io.swagger.v3.oas.annotations.Operation;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,16 +23,17 @@ public class PostSearchController {
 
   @Operation(summary = "제목으로 게시글 검색", description = "제목을 통해 게시글을 검색합니다.")
   @GetMapping("/title")
-  public ResponseEntity<List<PostDocument>> searchByTitle(@RequestParam String title) {
-    List<PostDocument> posts = postSearchService.searchByTitle(title);
+  public ResponseEntity<Page<PostDocument>> searchByTitle(@RequestParam String title,
+      @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+    Page<PostDocument> posts = postSearchService.searchByTitle(title, pageable);
     return ResponseEntity.ok(posts);
   }
 
   @Operation(summary = "해시태그로 게시글 검색", description = "해시태그를 통해 게시글을 검색합니다.")
   @GetMapping("/hashtag")
-  public ResponseEntity<List<PostDocument>> searchByHashtag(@RequestParam String hashtag) {
-    List<PostDocument> posts = postSearchService.searchByHashtag(hashtag);
+  public ResponseEntity<Page<PostDocument>> searchByHashtag(@RequestParam String hashtag,
+      @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+    Page<PostDocument> posts = postSearchService.searchByHashtag(hashtag, pageable);
     return ResponseEntity.ok(posts);
   }
-
 }

--- a/src/main/java/com/project/hireup/controller/PostSearchController.java
+++ b/src/main/java/com/project/hireup/controller/PostSearchController.java
@@ -1,0 +1,28 @@
+package com.project.hireup.controller;
+
+import com.project.hireup.entity.PostDocument;
+import com.project.hireup.service.PostSearchService;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/posts/search")
+@RequiredArgsConstructor
+public class PostSearchController {
+
+  private final PostSearchService postSearchService;
+
+  @Operation(summary = "제목으로 게시글 검색", description = "제목을 통해 게시글을 검색합니다.")
+  @GetMapping("/title")
+  public ResponseEntity<List<PostDocument>> searchByTitle(@RequestParam String title) {
+    List<PostDocument> posts = postSearchService.searchByTitle(title);
+    return ResponseEntity.ok(posts);
+  }
+
+}

--- a/src/main/java/com/project/hireup/controller/PostSearchController.java
+++ b/src/main/java/com/project/hireup/controller/PostSearchController.java
@@ -25,4 +25,11 @@ public class PostSearchController {
     return ResponseEntity.ok(posts);
   }
 
+  @Operation(summary = "해시태그로 게시글 검색", description = "해시태그를 통해 게시글을 검색합니다.")
+  @GetMapping("/hashtag")
+  public ResponseEntity<List<PostDocument>> searchByHashtag(@RequestParam String hashtag) {
+    List<PostDocument> posts = postSearchService.searchByHashtag(hashtag);
+    return ResponseEntity.ok(posts);
+  }
+
 }

--- a/src/main/java/com/project/hireup/entity/PostDocument.java
+++ b/src/main/java/com/project/hireup/entity/PostDocument.java
@@ -1,0 +1,38 @@
+package com.project.hireup.entity;
+
+import jakarta.persistence.Id;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Document(indexName = "posts")  // Elasticsearch 의 인덱스 이름
+public class PostDocument {
+
+  @Id
+  private Long id;
+
+  @Field(type = FieldType.Keyword)
+  private String title;
+
+  @Field(type = FieldType.Keyword)
+  private Set<String> hashtags;
+
+  public static PostDocument fromEntity(Post post) {
+    return PostDocument.builder()
+        .id(post.getId())
+        .title(post.getTitle())
+        .hashtags(post.getHashtags())
+        .build();
+  }
+}

--- a/src/main/java/com/project/hireup/repository/PostSearchRepository.java
+++ b/src/main/java/com/project/hireup/repository/PostSearchRepository.java
@@ -1,0 +1,15 @@
+package com.project.hireup.repository;
+
+import com.project.hireup.entity.PostDocument;
+import java.util.List;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface PostSearchRepository extends ElasticsearchRepository<PostDocument, Long> {
+
+  // 정확히 일치하는 제목 검색
+  List<PostDocument> findByTitle(String title);
+
+  // 정확히 일치하는 해시태그 검색
+  List<PostDocument> findByHashtags(String hashtag);
+
+}

--- a/src/main/java/com/project/hireup/repository/PostSearchRepository.java
+++ b/src/main/java/com/project/hireup/repository/PostSearchRepository.java
@@ -1,15 +1,16 @@
 package com.project.hireup.repository;
 
 import com.project.hireup.entity.PostDocument;
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
 public interface PostSearchRepository extends ElasticsearchRepository<PostDocument, Long> {
 
-  // 정확히 일치하는 제목 검색
-  List<PostDocument> findByTitle(String title);
+  // 정확히 일치하는 제목 검색 (페이징 처리)
+  Page<PostDocument> findByTitle(String title, Pageable pageable);
 
-  // 정확히 일치하는 해시태그 검색
-  List<PostDocument> findByHashtags(String hashtag);
+  // 정확히 일치하는 해시태그 검색 (페이징 처리)
+  Page<PostDocument> findByHashtags(String hashtag, Pageable pageable);
 
 }

--- a/src/main/java/com/project/hireup/service/PostSearchService.java
+++ b/src/main/java/com/project/hireup/service/PostSearchService.java
@@ -31,4 +31,9 @@ public class PostSearchService {
     return postSearchRepository.findByTitle(title);
   }
 
+  // 게시글 검색 (정확히 일치하는 해시태그)
+  public List<PostDocument> searchByHashtag(String hashtag) {
+    return postSearchRepository.findByHashtags(hashtag);
+  }
+
 }

--- a/src/main/java/com/project/hireup/service/PostSearchService.java
+++ b/src/main/java/com/project/hireup/service/PostSearchService.java
@@ -3,8 +3,9 @@ package com.project.hireup.service;
 import com.project.hireup.entity.Post;
 import com.project.hireup.entity.PostDocument;
 import com.project.hireup.repository.PostSearchRepository;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,14 +27,14 @@ public class PostSearchService {
     postSearchRepository.deleteById(postId);
   }
 
-  // 게시글 검색 (정확히 일치하는 제목)
-  public List<PostDocument> searchByTitle(String title) {
-    return postSearchRepository.findByTitle(title);
+  // 게시글 검색 (정확히 일치하는 제목, 페이징 처리)
+  public Page<PostDocument> searchByTitle(String title, Pageable pageable) {
+    return postSearchRepository.findByTitle(title, pageable);
   }
 
-  // 게시글 검색 (정확히 일치하는 해시태그)
-  public List<PostDocument> searchByHashtag(String hashtag) {
-    return postSearchRepository.findByHashtags(hashtag);
+  // 게시글 검색 (정확히 일치하는 해시태그, 페이징 처리)
+  public Page<PostDocument> searchByHashtag(String hashtag, Pageable pageable) {
+    return postSearchRepository.findByHashtags(hashtag, pageable);
   }
 
 }

--- a/src/main/java/com/project/hireup/service/PostSearchService.java
+++ b/src/main/java/com/project/hireup/service/PostSearchService.java
@@ -19,4 +19,10 @@ public class PostSearchService {
     postSearchRepository.save(PostDocument.fromEntity(post));
   }
 
+  // 게시글 삭제 (Elasticsearch에서도 삭제)
+  @Transactional
+  public void deletePost(Long postId) {
+    postSearchRepository.deleteById(postId);
+  }
+
 }

--- a/src/main/java/com/project/hireup/service/PostSearchService.java
+++ b/src/main/java/com/project/hireup/service/PostSearchService.java
@@ -3,6 +3,7 @@ package com.project.hireup.service;
 import com.project.hireup.entity.Post;
 import com.project.hireup.entity.PostDocument;
 import com.project.hireup.repository.PostSearchRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +24,11 @@ public class PostSearchService {
   @Transactional
   public void deletePost(Long postId) {
     postSearchRepository.deleteById(postId);
+  }
+
+  // 게시글 검색 (정확히 일치하는 제목)
+  public List<PostDocument> searchByTitle(String title) {
+    return postSearchRepository.findByTitle(title);
   }
 
 }

--- a/src/main/java/com/project/hireup/service/PostSearchService.java
+++ b/src/main/java/com/project/hireup/service/PostSearchService.java
@@ -1,0 +1,22 @@
+package com.project.hireup.service;
+
+import com.project.hireup.entity.Post;
+import com.project.hireup.entity.PostDocument;
+import com.project.hireup.repository.PostSearchRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PostSearchService {
+
+  private final PostSearchRepository postSearchRepository;
+
+  // 게시글 저장 (Elasticsearch에 동기화)
+  @Transactional
+  public void savePost(Post post) {
+    postSearchRepository.save(PostDocument.fromEntity(post));
+  }
+
+}

--- a/src/main/java/com/project/hireup/service/PostService.java
+++ b/src/main/java/com/project/hireup/service/PostService.java
@@ -33,6 +33,7 @@ public class PostService {
   private final PostRepository postRepository;
   private final CategoryService categoryService;
   private final FollowRepository followRepository;
+  private final PostSearchService postSearchService;
 
   // 게시글 생성
   @Transactional
@@ -50,7 +51,7 @@ public class PostService {
       throw new HireUpException(NO_PERMISSION_CATEGORY);
     }
 
-    postRepository.save(Post.builder()
+    Post post = postRepository.save(Post.builder()
         .title(requestDto.getTitle())
         .content(requestDto.getContent())
         .category(category)
@@ -58,6 +59,9 @@ public class PostService {
         .status(requestDto.getStatus())
         .user(user)
         .build());
+
+    // Elasticsearch 에 저장
+    postSearchService.savePost(post);
   }
 
   // 특정 게시글 조회
@@ -146,6 +150,9 @@ public class PostService {
 
     // 변경 사항 저장
     postRepository.save(post);
+
+    // Elasticsearch 에 업데이트
+    postSearchService.savePost(post);
   }
 
   // 게시글 삭제

--- a/src/main/java/com/project/hireup/service/PostService.java
+++ b/src/main/java/com/project/hireup/service/PostService.java
@@ -168,6 +168,10 @@ public class PostService {
       throw new HireUpException(CAN_NOT_UPDATE_POST);
     }
 
+    // 게시글 삭제 (DB에서 삭제)
     postRepository.delete(post);
+
+    // Elasticsearch에서도 삭제
+    postSearchService.deletePost(postId);
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,6 +42,9 @@ spring:
     cache:
       type: redis      # 캐시 저장소를 Redis로 설정
 
+  elasticsearch:
+    uris: http://localhost:9200
+
   admin:
     token: ${ADMIN_TOKEN}
 


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 기존 PostService에서 게시글 생성, 수정, 삭제, 조회기능은 데이터베이스에만 적용되었으며, 검색 기능은 미구현 상태.
- 제목과 해시태그를 기반으로 게시글을 검색할 수 있는 기능이 없었음.

**TO-BE**
- ElasticSearch를 도입하여 제목과 해시태그를 기반으로 게시글을 검색할 수 있는 기능 구현.
- PostService에서 게시글 생성, 수정 시 ElasticSearch 인덱스에 데이터 추가 및 업데이트.
- PostService에서 게시글 삭제 시 ElasticSearch 인덱스에서도 데이터 삭제.
- PostSearchController를 통해 제목과 해시태그로 검색할 수 있는 API 제공:
  - `/api/posts/search/title?title=<검색어>`: 제목으로 검색.
  - `/api/posts/search/hashtag?hashtag=<검색어>`: 해시태그로 검색.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- API 테스트 
- [x] 제목으로 검색 테스트 완료 (`/api/posts/search/title?title=<검색어>`).
- [x] 해시태그로 검색 테스트 완료 (`/api/posts/search/hashtag?hashtag=<검색어>`).
- [x] 게시글 생성 시 ElasticSearch 인덱스 저장 확인.
- [x] 게시글 수정 시 ElasticSearch 인덱스 업데이트 확인.
- [x] 게시글 삭제 시 ElasticSearch 인덱스 삭제 확인.